### PR TITLE
Fixed bug falsely showing status bar on alert display

### DIFF
--- a/Classes/PXAlertView.m
+++ b/Classes/PXAlertView.m
@@ -401,6 +401,11 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 #pragma mark -
 #pragma mark UIViewController
 
+- (BOOL)prefersStatusBarHidden
+{
+	return [UIApplication sharedApplication].statusBarHidden;
+}
+
 - (BOOL)shouldAutorotate
 {
     return YES;


### PR DESCRIPTION
When the current UIViewController has no status bar shown…

…like by implementing:

``` objc
- (BOOL)prefersStatusBarHidden
{
    return YES;
}
```

…then PXAlertView currently shows one anyway.
