### PR TITLE
Fix compiler warning for catagory method overiding class method

### DIFF
--- a/Classes/PXAlertView+Customization.m
+++ b/Classes/PXAlertView+Customization.m
@@ -57,7 +57,7 @@ void * const kOtherBGKey = (void * const) &kOtherBGKey;
 
 #pragma mark -
 #pragma mark Buttons Customization
-- (void)setBackgroundColorForButton:(id)sender
+- (void)setCustomBackgroundColorForButton:(id)sender
 {
     if (sender == self.cancelButton && self.cancelButtonBackgroundColor) {
         self.cancelButton.backgroundColor = self.cancelButtonBackgroundColor;


### PR DESCRIPTION
Fixes #12 by differentiating the catagory method name
