### PR TITLE
Set alertWindow.rootViewController = nil

### DIFF
--- a/Classes/PXAlertView.m
+++ b/Classes/PXAlertView.m
@@ -341,6 +341,7 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
             self.backgroundView.alpha = 0;
         } completion:^(BOOL finished) {
             [self.alertWindow removeFromSuperview];
+            self.alertWindow.rootViewController = nil;
             self.alertWindow = nil;
             [self.mainWindow makeKeyAndVisible];
         }];


### PR DESCRIPTION
In the demo, when calling `show5StackedAlertViews:`, `self.alertWindow` is remaining, even though it is set to nil, and is blocking the main window. I was able to confirm this using Reveal. Setting `alertWindow.rootViewController` to nil seems to clear this up.

Out of curiosity, would this be due to something holding a reference to `alertWindow`, and not allowing ARC to release it? I'm still trying to get a handle on all this, and while I was able to make it work, I want to make sure I correctly understand _how_ I made it work.
