### PR TITLE
iOS 8, keyboard dodging, (optional)UIAlertView swizzling, text overflow scrolling, and bug fixes

### DIFF
--- a/Classes/PXAlertView.m
+++ b/Classes/PXAlertView.m
@@ -413,6 +413,7 @@ static const CGFloat AlertViewVerticalEdgeMinMargin = 25;
 	
 	[UIView animateWithDuration:(animated ? 0.2 : 0) animations:^{
 		self.alertView.alpha = 0;
+		self.alertWindow.alpha = 0;
 	} completion:^(BOOL finished) {
 		if (self.completion) {
 			BOOL cancelled = NO;

--- a/Classes/PXAlertView.m
+++ b/Classes/PXAlertView.m
@@ -49,145 +49,145 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 
 - (UIWindow *)windowWithLevel:(UIWindowLevel)windowLevel
 {
-    NSArray *windows = [[UIApplication sharedApplication] windows];
-    for (UIWindow *window in windows) {
-        if (window.windowLevel == windowLevel) {
-            return window;
-        }
-    }
-    return nil;
+	NSArray *windows = [[UIApplication sharedApplication] windows];
+	for (UIWindow *window in windows) {
+		if (window.windowLevel == windowLevel) {
+			return window;
+		}
+	}
+	return nil;
 }
 
 - (id)initWithTitle:(NSString *)title
-            message:(NSString *)message
-        cancelTitle:(NSString *)cancelTitle
-         otherTitle:(NSString *)otherTitle
+			message:(NSString *)message
+		cancelTitle:(NSString *)cancelTitle
+		 otherTitle:(NSString *)otherTitle
  buttonsShouldStack:(BOOL)shouldstack
-        contentView:(UIView *)contentView
-         completion:(PXAlertViewCompletionBlock)completion
+		contentView:(UIView *)contentView
+		 completion:(PXAlertViewCompletionBlock)completion
 {
-    return [self initWithTitle:title
-                       message:message
-                   cancelTitle:cancelTitle
-                   otherTitles:(otherTitle) ? @[ otherTitle ] : nil
-            buttonsShouldStack:(BOOL)shouldstack
-                   contentView:contentView
-                    completion:completion];
+	return [self initWithTitle:title
+					   message:message
+				   cancelTitle:cancelTitle
+				   otherTitles:(otherTitle) ? @[ otherTitle ] : nil
+			buttonsShouldStack:(BOOL)shouldstack
+				   contentView:contentView
+					completion:completion];
 }
 
 - (id)initWithTitle:(NSString *)title
-            message:(NSString *)message
-        cancelTitle:(NSString *)cancelTitle
-        otherTitles:(NSArray *)otherTitles
+			message:(NSString *)message
+		cancelTitle:(NSString *)cancelTitle
+		otherTitles:(NSArray *)otherTitles
  buttonsShouldStack:(BOOL)shouldstack
-        contentView:(UIView *)contentView
-         completion:(PXAlertViewCompletionBlock)completion
+		contentView:(UIView *)contentView
+		 completion:(PXAlertViewCompletionBlock)completion
 {
-    self = [super init];
-    if (self) {
-        self.mainWindow = [self windowWithLevel:UIWindowLevelNormal];
-        self.alertWindow = [self windowWithLevel:UIWindowLevelAlert];
-        
-        if (!self.alertWindow) {
-            self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-            self.alertWindow.windowLevel = UIWindowLevelAlert;
-            self.alertWindow.backgroundColor = [UIColor clearColor];
-        }
-        self.alertWindow.rootViewController = self;
-        
-        CGRect frame = [self frameForOrientation];
-        self.view.frame = frame;
-        
-        self.backgroundView = [[UIView alloc] initWithFrame:frame];
-        self.backgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.25];
-        self.backgroundView.alpha = 0;
-        [self.view addSubview:self.backgroundView];
-        
-        self.alertView = [[UIView alloc] init];
-        self.alertView.backgroundColor = [UIColor colorWithWhite:0.25 alpha:1];
-        self.alertView.layer.cornerRadius = 8.0;
-        self.alertView.layer.opacity = .95;
-        self.alertView.clipsToBounds = YES;
-        [self.view addSubview:self.alertView];
-        
-        // Title
-        self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(AlertViewContentMargin,
-                                                                    AlertViewVerticalElementSpace,
-                                                                    AlertViewWidth - AlertViewContentMargin*2,
-                                                                    44)];
-        self.titleLabel.text = title;
-        self.titleLabel.backgroundColor = [UIColor clearColor];
-        self.titleLabel.textColor = [UIColor whiteColor];
-        self.titleLabel.textAlignment = NSTextAlignmentCenter;
-        self.titleLabel.font = [UIFont boldSystemFontOfSize:17];
-        self.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
-        self.titleLabel.numberOfLines = 0;
-        self.titleLabel.frame = [self adjustLabelFrameHeight:self.titleLabel];
-        [self.alertView addSubview:self.titleLabel];
-        
-        CGFloat messageLabelY = self.titleLabel.frame.origin.y + self.titleLabel.frame.size.height + AlertViewVerticalElementSpace;
-        
-        // Optional Content View
-        if (contentView) {
-            self.contentView = contentView;
-            self.contentView.frame = CGRectMake(0,
-                                                messageLabelY,
-                                                self.contentView.frame.size.width,
-                                                self.contentView.frame.size.height);
-            self.contentView.center = CGPointMake(AlertViewWidth/2, self.contentView.center.y);
-            [self.alertView addSubview:self.contentView];
-            messageLabelY += contentView.frame.size.height + AlertViewVerticalElementSpace;
-        }
-
-        // Message
-        self.messageLabel = [[UILabel alloc] initWithFrame:CGRectMake(AlertViewContentMargin,
-                                                                      messageLabelY,
-                                                                      AlertViewWidth - AlertViewContentMargin*2,
-                                                                      44)];
-        self.messageLabel.text = message;
-        self.messageLabel.backgroundColor = [UIColor clearColor];
-        self.messageLabel.textColor = [UIColor whiteColor];
-        self.messageLabel.textAlignment = NSTextAlignmentCenter;
-        self.messageLabel.font = [UIFont systemFontOfSize:15];
-        self.messageLabel.lineBreakMode = NSLineBreakByWordWrapping;
-        self.messageLabel.numberOfLines = 0;
-        self.messageLabel.frame = [self adjustLabelFrameHeight:self.messageLabel];
-        [self.alertView addSubview:self.messageLabel];
-        
-        // Line
-        CALayer *lineLayer = [self lineLayer];
-        lineLayer.frame = CGRectMake(0, self.messageLabel.frame.origin.y + self.messageLabel.frame.size.height + AlertViewVerticalElementSpace, AlertViewWidth, AlertViewLineLayerWidth);
-        [self.alertView.layer addSublayer:lineLayer];
-        
-        self.buttonsY = lineLayer.frame.origin.y + lineLayer.frame.size.height;
-        
-        // Buttons
-        self.buttonsShouldStack = shouldstack;
-        
-        if (cancelTitle) {
-            [self addButtonWithTitle:cancelTitle];
-        } else {
-            [self addButtonWithTitle:NSLocalizedString(@"Ok", nil)];
-        }
-        
-        if (otherTitles && [otherTitles count] > 0) {
-            for (id otherTitle in otherTitles) {
-                NSParameterAssert([otherTitle isKindOfClass:[NSString class]]);
-                [self addButtonWithTitle:(NSString *)otherTitle];
-            }
-        }
-        
-        self.alertView.bounds = CGRectMake(0, 0, AlertViewWidth, 150);
-        
-        if (completion) {
-            self.completion = completion;
-        }
-
-        [self resizeViews];
-        
-        self.alertView.center = [self centerWithFrame:frame];
-        
-        [self setupGestures];
+	self = [super init];
+	if (self) {
+		self.mainWindow = [self windowWithLevel:UIWindowLevelNormal];
+		self.alertWindow = [self windowWithLevel:UIWindowLevelAlert];
+		
+		if (!self.alertWindow) {
+			self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+			self.alertWindow.windowLevel = UIWindowLevelAlert;
+			self.alertWindow.backgroundColor = [UIColor clearColor];
+		}
+		self.alertWindow.rootViewController = self;
+		
+		CGRect frame = [self frameForOrientation];
+		self.view.frame = frame;
+		
+		self.backgroundView = [[UIView alloc] initWithFrame:frame];
+		self.backgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.25];
+		self.backgroundView.alpha = 0;
+		[self.view addSubview:self.backgroundView];
+		
+		self.alertView = [[UIView alloc] init];
+		self.alertView.backgroundColor = [UIColor colorWithWhite:0.25 alpha:1];
+		self.alertView.layer.cornerRadius = 8.0;
+		self.alertView.layer.opacity = .95;
+		self.alertView.clipsToBounds = YES;
+		[self.view addSubview:self.alertView];
+		
+		// Title
+		self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(AlertViewContentMargin,
+																	AlertViewVerticalElementSpace,
+																	AlertViewWidth - AlertViewContentMargin*2,
+																	44)];
+		self.titleLabel.text = title;
+		self.titleLabel.backgroundColor = [UIColor clearColor];
+		self.titleLabel.textColor = [UIColor whiteColor];
+		self.titleLabel.textAlignment = NSTextAlignmentCenter;
+		self.titleLabel.font = [UIFont boldSystemFontOfSize:17];
+		self.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
+		self.titleLabel.numberOfLines = 0;
+		self.titleLabel.frame = [self adjustLabelFrameHeight:self.titleLabel];
+		[self.alertView addSubview:self.titleLabel];
+		
+		CGFloat messageLabelY = self.titleLabel.frame.origin.y + self.titleLabel.frame.size.height + AlertViewVerticalElementSpace;
+		
+		// Optional Content View
+		if (contentView) {
+			self.contentView = contentView;
+			self.contentView.frame = CGRectMake(0,
+												messageLabelY,
+												self.contentView.frame.size.width,
+												self.contentView.frame.size.height);
+			self.contentView.center = CGPointMake(AlertViewWidth/2, self.contentView.center.y);
+			[self.alertView addSubview:self.contentView];
+			messageLabelY += contentView.frame.size.height + AlertViewVerticalElementSpace;
+		}
+		
+		// Message
+		self.messageLabel = [[UILabel alloc] initWithFrame:CGRectMake(AlertViewContentMargin,
+																	  messageLabelY,
+																	  AlertViewWidth - AlertViewContentMargin*2,
+																	  44)];
+		self.messageLabel.text = message;
+		self.messageLabel.backgroundColor = [UIColor clearColor];
+		self.messageLabel.textColor = [UIColor whiteColor];
+		self.messageLabel.textAlignment = NSTextAlignmentCenter;
+		self.messageLabel.font = [UIFont systemFontOfSize:15];
+		self.messageLabel.lineBreakMode = NSLineBreakByWordWrapping;
+		self.messageLabel.numberOfLines = 0;
+		self.messageLabel.frame = [self adjustLabelFrameHeight:self.messageLabel];
+		[self.alertView addSubview:self.messageLabel];
+		
+		// Line
+		CALayer *lineLayer = [self lineLayer];
+		lineLayer.frame = CGRectMake(0, self.messageLabel.frame.origin.y + self.messageLabel.frame.size.height + AlertViewVerticalElementSpace, AlertViewWidth, AlertViewLineLayerWidth);
+		[self.alertView.layer addSublayer:lineLayer];
+		
+		self.buttonsY = lineLayer.frame.origin.y + lineLayer.frame.size.height;
+		
+		// Buttons
+		self.buttonsShouldStack = shouldstack;
+		
+		if (cancelTitle) {
+			[self addButtonWithTitle:cancelTitle];
+		} else {
+			[self addButtonWithTitle:NSLocalizedString(@"Ok", nil)];
+		}
+		
+		if (otherTitles && [otherTitles count] > 0) {
+			for (id otherTitle in otherTitles) {
+				NSParameterAssert([otherTitle isKindOfClass:[NSString class]]);
+				[self addButtonWithTitle:(NSString *)otherTitle];
+			}
+		}
+		
+		self.alertView.bounds = CGRectMake(0, 0, AlertViewWidth, 150);
+		
+		if (completion) {
+			self.completion = completion;
+		}
+		
+		[self resizeViews];
+		
+		self.alertView.center = [self centerWithFrame:frame];
+		
+		[self setupGestures];
 		
 		if ((self = [super init])) {
 			NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
@@ -195,8 +195,8 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 			[center addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
 		}
 		return self;
-    }
-    return self;
+	}
+	return self;
 }
 
 - (void)keyboardWillShown:(NSNotification*)notification
@@ -204,7 +204,7 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 	if(self.isVisible)
 	{
 		CGRect keyboardFrameBeginRect = [[[notification userInfo] valueForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue];
-		if (self.interfaceOrientation == UIInterfaceOrientationLandscapeLeft || self.interfaceOrientation == UIInterfaceOrientationLandscapeRight) {
+		if ([[[UIDevice currentDevice] systemVersion] floatValue] < 8 && (self.interfaceOrientation == UIInterfaceOrientationLandscapeLeft || self.interfaceOrientation == UIInterfaceOrientationLandscapeRight)) {
 			keyboardFrameBeginRect = (CGRect){keyboardFrameBeginRect.origin.y, keyboardFrameBeginRect.origin.x, keyboardFrameBeginRect.size.height, keyboardFrameBeginRect.size.width};
 		}
 		CGRect interfaceFrame = [self frameForOrientation];
@@ -221,7 +221,7 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 
 - (void)keyboardWillHide:(NSNotification*)notification
 {
-    if(self.isVisible)
+	if(self.isVisible)
 	{
 		[UIView animateWithDuration:.35 delay:0 options:0x70000 animations:^(void)
 		 {
@@ -235,222 +235,225 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 	UIWindow *window = [[UIApplication sharedApplication].windows count] > 0 ? [[UIApplication sharedApplication].windows objectAtIndex:0] : nil;
 	if (!window)
 		window = [UIApplication sharedApplication].keyWindow;
-	return [[[window subviews] objectAtIndex:0] bounds];
+	if([[window subviews] count] > 0)
+	{
+		return [[[window subviews] objectAtIndex:0] bounds];
+	}
+	return [[self windowWithLevel:UIWindowLevelNormal] bounds];
 }
 
 - (CGRect)adjustLabelFrameHeight:(UILabel *)label
 {
-    CGFloat height;
-
-    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        CGSize size = [label.text sizeWithFont:label.font
-                             constrainedToSize:CGSizeMake(label.frame.size.width, FLT_MAX)
-                                 lineBreakMode:NSLineBreakByWordWrapping];
-
-        height = size.height;
-        #pragma clang diagnostic pop
-    } else {
-        NSStringDrawingContext *context = [[NSStringDrawingContext alloc] init];
-        context.minimumScaleFactor = 1.0;
-        CGRect bounds = [label.text boundingRectWithSize:CGSizeMake(label.frame.size.width, FLT_MAX)
-                                                 options:NSStringDrawingUsesLineFragmentOrigin
-                                              attributes:@{NSFontAttributeName:label.font}
-                                                 context:context];
-        height = bounds.size.height;
-    }
-    
-    return CGRectMake(label.frame.origin.x, label.frame.origin.y, label.frame.size.width, height);
+	CGFloat height;
+	
+	if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		CGSize size = [label.text sizeWithFont:label.font
+							 constrainedToSize:CGSizeMake(label.frame.size.width, FLT_MAX)
+								 lineBreakMode:NSLineBreakByWordWrapping];
+		
+		height = size.height;
+#pragma clang diagnostic pop
+	} else {
+		NSStringDrawingContext *context = [[NSStringDrawingContext alloc] init];
+		context.minimumScaleFactor = 1.0;
+		CGRect bounds = [label.text boundingRectWithSize:CGSizeMake(label.frame.size.width, FLT_MAX)
+												 options:NSStringDrawingUsesLineFragmentOrigin
+											  attributes:@{NSFontAttributeName:label.font}
+												 context:context];
+		height = bounds.size.height;
+	}
+	
+	return CGRectMake(label.frame.origin.x, label.frame.origin.y, label.frame.size.width, height);
 }
 
 - (UIButton *)genericButton
 {
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-    button.backgroundColor = [UIColor clearColor];
-    button.titleLabel.font = [UIFont systemFontOfSize:17];
-    button.titleLabel.adjustsFontSizeToFitWidth = YES;
-    button.titleEdgeInsets = UIEdgeInsetsMake(2, 2, 2, 2);
-    [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-    [button setTitleColor:[UIColor colorWithWhite:0.25 alpha:1] forState:UIControlStateHighlighted];
-    [button addTarget:self action:@selector(dismiss:) forControlEvents:UIControlEventTouchUpInside];
-    [button addTarget:self action:@selector(setBackgroundColorForButton:) forControlEvents:UIControlEventTouchDown];
-    [button addTarget:self action:@selector(clearBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragExit];
-    return button;
+	UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+	button.backgroundColor = [UIColor clearColor];
+	button.titleLabel.font = [UIFont systemFontOfSize:17];
+	button.titleLabel.adjustsFontSizeToFitWidth = YES;
+	button.titleEdgeInsets = UIEdgeInsetsMake(2, 2, 2, 2);
+	[button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+	[button setTitleColor:[UIColor colorWithWhite:0.25 alpha:1] forState:UIControlStateHighlighted];
+	[button addTarget:self action:@selector(dismiss:) forControlEvents:UIControlEventTouchUpInside];
+	[button addTarget:self action:@selector(setBackgroundColorForButton:) forControlEvents:UIControlEventTouchDown];
+	[button addTarget:self action:@selector(clearBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragExit];
+	return button;
 }
 
 - (CGPoint)centerWithFrame:(CGRect)frame
 {
-    return CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame) - [self statusBarOffset]);
+	return CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame) - [self statusBarOffset]);
 }
 
 - (CGFloat)statusBarOffset
 {
-    CGFloat statusBarOffset = 0;
-    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
-        statusBarOffset = 20;
-    }
-    return statusBarOffset;
+	CGFloat statusBarOffset = 0;
+	if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+		statusBarOffset = 20;
+	}
+	return statusBarOffset;
 }
 
 - (void)setupGestures
 {
-    self.tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismiss:)];
-    [self.tap setNumberOfTapsRequired:1];
-    [self.backgroundView setUserInteractionEnabled:YES];
-    [self.backgroundView setMultipleTouchEnabled:NO];
-    [self.backgroundView addGestureRecognizer:self.tap];
+	self.tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismiss:)];
+	[self.tap setNumberOfTapsRequired:1];
+	[self.backgroundView setUserInteractionEnabled:YES];
+	[self.backgroundView setMultipleTouchEnabled:NO];
+	[self.backgroundView addGestureRecognizer:self.tap];
 }
 
 - (void)resizeViews
 {
-    CGFloat totalHeight = 0;
-    for (UIView *view in [self.alertView subviews]) {
-        if ([view class] != [UIButton class]) {
-            totalHeight += view.frame.size.height + AlertViewVerticalElementSpace;
-        }
-    }
-    if (self.buttons) {
-        NSUInteger otherButtonsCount = [self.buttons count];
-        if (self.buttonsShouldStack) {
-            totalHeight += AlertViewButtonHeight * otherButtonsCount;
-        } else {
-            totalHeight += AlertViewButtonHeight * (otherButtonsCount > 2 ? otherButtonsCount : 1);
-        }
-    }
-    totalHeight += AlertViewVerticalElementSpace;
-    
-    self.alertView.frame = CGRectMake(self.alertView.frame.origin.x,
-                                      self.alertView.frame.origin.y,
-                                      self.alertView.frame.size.width,
-                                      totalHeight);
+	CGFloat totalHeight = 0;
+	for (UIView *view in [self.alertView subviews]) {
+		if ([view class] != [UIButton class]) {
+			totalHeight += view.frame.size.height + AlertViewVerticalElementSpace;
+		}
+	}
+	if (self.buttons) {
+		NSUInteger otherButtonsCount = [self.buttons count];
+		if (self.buttonsShouldStack) {
+			totalHeight += AlertViewButtonHeight * otherButtonsCount;
+		} else {
+			totalHeight += AlertViewButtonHeight * (otherButtonsCount > 2 ? otherButtonsCount : 1);
+		}
+	}
+	totalHeight += AlertViewVerticalElementSpace;
+	
+	self.alertView.frame = CGRectMake(self.alertView.frame.origin.x,
+									  self.alertView.frame.origin.y,
+									  self.alertView.frame.size.width,
+									  totalHeight);
 }
 
 - (void)setBackgroundColorForButton:(id)sender
 {
-    [sender setBackgroundColor:[UIColor colorWithRed:94/255.0 green:196/255.0 blue:221/255.0 alpha:1.0]];
+	[sender setBackgroundColor:[UIColor colorWithRed:94/255.0 green:196/255.0 blue:221/255.0 alpha:1.0]];
 }
 
 - (void)clearBackgroundColorForButton:(id)sender
 {
-    [sender setBackgroundColor:[UIColor clearColor]];
+	[sender setBackgroundColor:[UIColor clearColor]];
 }
 
 - (void)show
 {
-    [[PXAlertViewStack sharedInstance] push:self];
+	[[PXAlertViewStack sharedInstance] push:self];
 }
 
 - (void)showInternal
 {
-    [self.alertWindow addSubview:self.view];
-    [self.alertWindow makeKeyAndVisible];
-    self.visible = YES;
-    [self showBackgroundView];
-    [self showAlertAnimation];
+	[self.alertWindow addSubview:self.view];
+	[self.alertWindow makeKeyAndVisible];
+	self.visible = YES;
+	[self showBackgroundView];
+	[self showAlertAnimation];
 }
 
 - (void)showBackgroundView
 {
-    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
-        self.mainWindow.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
-        [self.mainWindow tintColorDidChange];
-    }
-    [UIView animateWithDuration:0.3 animations:^{
-        self.backgroundView.alpha = 1;
-    }];
+	if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
+		self.mainWindow.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
+		[self.mainWindow tintColorDidChange];
+	}
+	[UIView animateWithDuration:0.3 animations:^{
+		self.backgroundView.alpha = 1;
+	}];
 }
 
 - (void)hide
 {
-    [self.view removeFromSuperview];
+	[self.view removeFromSuperview];
 }
 
 - (void)dismiss:(id)sender
 {
-    [self dismiss:sender animated:YES];
+	[self dismiss:sender animated:YES];
 }
 
 - (void)dismiss:(id)sender animated:(BOOL)animated
 {
-    self.visible = NO;
-
-    if ([[[PXAlertViewStack sharedInstance] alertViews] count] == 1) {
-        if (animated) {
-            [self dismissAlertAnimation];
-        }
-        if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
-            self.mainWindow.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
-            [self.mainWindow tintColorDidChange];
-        }
-        [UIView animateWithDuration:(animated ? 0.2 : 0) animations:^{
-            self.backgroundView.alpha = 0;
-        } completion:^(BOOL finished) {
-            [self.alertWindow setHidden:YES];
-            [self.alertWindow removeFromSuperview];
-            self.alertWindow.rootViewController = nil;
-            self.alertWindow = nil;
-            [self.mainWindow makeKeyAndVisible];
-        }];
-    }
-    
-    [UIView animateWithDuration:(animated ? 0.2 : 0) animations:^{
-        self.alertView.alpha = 0;
-    } completion:^(BOOL finished) {
-        [[PXAlertViewStack sharedInstance] pop:self];
-        [self.view removeFromSuperview];
-    }];
-
-    if (self.completion) {
-        BOOL cancelled = NO;
-        if (sender == self.cancelButton || sender == self.tap) {
-            cancelled = YES;
-        }
-        NSInteger buttonIndex = -1;
-        if (self.buttons) {
-            NSUInteger index = [self.buttons indexOfObject:sender];
-            if (buttonIndex != NSNotFound) {
-                buttonIndex = index;
-            }
-        }
-        self.completion(cancelled, buttonIndex);
-    }
+	self.visible = NO;
+	
+	[UIView animateWithDuration:(animated ? 0.2 : 0) animations:^{
+		self.alertView.alpha = 0;
+	} completion:^(BOOL finished) {
+		if (self.completion) {
+			BOOL cancelled = NO;
+			if (sender == self.cancelButton || sender == self.tap) {
+				cancelled = YES;
+			}
+			NSInteger buttonIndex = -1;
+			if (self.buttons) {
+				NSUInteger index = [self.buttons indexOfObject:sender];
+				if (buttonIndex != NSNotFound) {
+					buttonIndex = index;
+				}
+			}
+			self.completion(cancelled, buttonIndex);
+		}
+		
+		if ([[[PXAlertViewStack sharedInstance] alertViews] count] == 1) {
+			if (animated) {
+				[self dismissAlertAnimation];
+			}
+			if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
+				self.mainWindow.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
+				[self.mainWindow tintColorDidChange];
+			}
+			[UIView animateWithDuration:(animated ? 0.2 : 0) animations:^{
+				self.backgroundView.alpha = 0;
+				[self.alertWindow setHidden:YES];
+				[self.alertWindow removeFromSuperview];
+				self.alertWindow.rootViewController = nil;
+				self.alertWindow = nil;
+			} completion:^(BOOL finished) {
+				[self.mainWindow makeKeyAndVisible];
+			}];
+		}
+		
+		[[PXAlertViewStack sharedInstance] pop:self];
+	}];
 }
 
 - (void)showAlertAnimation
 {
-    CAKeyframeAnimation *animation = [CAKeyframeAnimation animationWithKeyPath:@"transform"];
-
-    animation.values = @[[NSValue valueWithCATransform3D:CATransform3DMakeScale(1.2, 1.2, 1)],
-                         [NSValue valueWithCATransform3D:CATransform3DMakeScale(1.05, 1.05, 1)],
-                         [NSValue valueWithCATransform3D:CATransform3DMakeScale(1.0, 1.0, 1)]];
-    animation.keyTimes = @[ @0, @0.5, @1 ];
-    animation.fillMode = kCAFillModeForwards;
-    animation.removedOnCompletion = NO;
-    animation.duration = .3;
-
-    [self.alertView.layer addAnimation:animation forKey:@"showAlert"];
+	CAKeyframeAnimation *animation = [CAKeyframeAnimation animationWithKeyPath:@"transform"];
+	
+	animation.values = @[[NSValue valueWithCATransform3D:CATransform3DMakeScale(1.2, 1.2, 1)],
+						 [NSValue valueWithCATransform3D:CATransform3DMakeScale(1.05, 1.05, 1)],
+						 [NSValue valueWithCATransform3D:CATransform3DMakeScale(1.0, 1.0, 1)]];
+	animation.keyTimes = @[ @0, @0.5, @1 ];
+	animation.fillMode = kCAFillModeForwards;
+	animation.removedOnCompletion = NO;
+	animation.duration = .3;
+	
+	[self.alertView.layer addAnimation:animation forKey:@"showAlert"];
 }
 
 - (void)dismissAlertAnimation
 {
-    CAKeyframeAnimation *animation = [CAKeyframeAnimation animationWithKeyPath:@"transform"];
-
-    animation.values = @[[NSValue valueWithCATransform3D:CATransform3DMakeScale(1.0, 1.0, 1)],
-                         [NSValue valueWithCATransform3D:CATransform3DMakeScale(0.95, 0.95, 1)],
-                         [NSValue valueWithCATransform3D:CATransform3DMakeScale(0.8, 0.8, 1)]];
-    animation.keyTimes = @[ @0, @0.5, @1 ];
-    animation.fillMode = kCAFillModeRemoved;
-    animation.duration = .2;
-
-    [self.alertView.layer addAnimation:animation forKey:@"dismissAlert"];
+	CAKeyframeAnimation *animation = [CAKeyframeAnimation animationWithKeyPath:@"transform"];
+	
+	animation.values = @[[NSValue valueWithCATransform3D:CATransform3DMakeScale(1.0, 1.0, 1)],
+						 [NSValue valueWithCATransform3D:CATransform3DMakeScale(0.95, 0.95, 1)],
+						 [NSValue valueWithCATransform3D:CATransform3DMakeScale(0.8, 0.8, 1)]];
+	animation.keyTimes = @[ @0, @0.5, @1 ];
+	animation.fillMode = kCAFillModeRemoved;
+	animation.duration = .2;
+	
+	[self.alertView.layer addAnimation:animation forKey:@"dismissAlert"];
 }
 
 - (CALayer *)lineLayer
 {
-    CALayer *lineLayer = [CALayer layer];
-    lineLayer.backgroundColor = [[UIColor colorWithWhite:0.90 alpha:0.3] CGColor];
-    return lineLayer;
+	CALayer *lineLayer = [CALayer layer];
+	lineLayer.backgroundColor = [[UIColor colorWithWhite:0.90 alpha:0.3] CGColor];
+	return lineLayer;
 }
 
 #pragma mark -
@@ -463,24 +466,24 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 
 - (BOOL)shouldAutorotate
 {
-    return YES;
+	return YES;
 }
 
 - (NSUInteger)supportedInterfaceOrientations
 {
-    return UIInterfaceOrientationMaskAll;
+	return UIInterfaceOrientationMaskAll;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
-    return YES;
+	return YES;
 }
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation duration:(NSTimeInterval)duration
 {
-    CGRect frame = [self frameForOrientation];
-    self.backgroundView.frame = frame;
-    self.alertView.center = [self centerWithFrame:frame];
+	CGRect frame = [self frameForOrientation];
+	self.backgroundView.frame = frame;
+	self.alertView.center = [self centerWithFrame:frame];
 }
 
 #pragma mark -
@@ -488,205 +491,205 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 
 + (instancetype)showAlertWithTitle:(NSString *)title
 {
-    return [[self class] showAlertWithTitle:title message:nil cancelTitle:NSLocalizedString(@"Ok", nil) completion:nil];
+	return [[self class] showAlertWithTitle:title message:nil cancelTitle:NSLocalizedString(@"Ok", nil) completion:nil];
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
+						   message:(NSString *)message
 {
-    return [[self class] showAlertWithTitle:title message:message cancelTitle:NSLocalizedString(@"Ok", nil) completion:nil];
+	return [[self class] showAlertWithTitle:title message:message cancelTitle:NSLocalizedString(@"Ok", nil) completion:nil];
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    return [[self class] showAlertWithTitle:title message:message cancelTitle:NSLocalizedString(@"Ok", nil) completion:completion];
+	return [[self class] showAlertWithTitle:title message:message cancelTitle:NSLocalizedString(@"Ok", nil) completion:completion];
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                       cancelTitle:(NSString *)cancelTitle
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+					   cancelTitle:(NSString *)cancelTitle
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    PXAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                             cancelTitle:cancelTitle
-                                              otherTitle:nil
-                                      buttonsShouldStack:NO
-                                             contentView:nil
-                                              completion:completion];
-    [alertView show];
-    return alertView;
+	PXAlertView *alertView = [[self alloc] initWithTitle:title
+												 message:message
+											 cancelTitle:cancelTitle
+											  otherTitle:nil
+									  buttonsShouldStack:NO
+											 contentView:nil
+											  completion:completion];
+	[alertView show];
+	return alertView;
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                       cancelTitle:(NSString *)cancelTitle
-                        otherTitle:(NSString *)otherTitle
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+					   cancelTitle:(NSString *)cancelTitle
+						otherTitle:(NSString *)otherTitle
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    PXAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                             cancelTitle:cancelTitle
-                                              otherTitle:otherTitle
-                                      buttonsShouldStack:NO
-                                             contentView:nil
-                                              completion:completion];
-    [alertView show];
-    return alertView;
+	PXAlertView *alertView = [[self alloc] initWithTitle:title
+												 message:message
+											 cancelTitle:cancelTitle
+											  otherTitle:otherTitle
+									  buttonsShouldStack:NO
+											 contentView:nil
+											  completion:completion];
+	[alertView show];
+	return alertView;
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                       cancelTitle:(NSString *)cancelTitle
-                        otherTitle:(NSString *)otherTitle
-                buttonsShouldStack:(BOOL)shouldStack
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+					   cancelTitle:(NSString *)cancelTitle
+						otherTitle:(NSString *)otherTitle
+				buttonsShouldStack:(BOOL)shouldStack
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    PXAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                             cancelTitle:cancelTitle
-                                              otherTitle:otherTitle
-                                      buttonsShouldStack:shouldStack
-                                             contentView:nil
-                                              completion:completion];
-    [alertView show];
-    return alertView;
+	PXAlertView *alertView = [[self alloc] initWithTitle:title
+												 message:message
+											 cancelTitle:cancelTitle
+											  otherTitle:otherTitle
+									  buttonsShouldStack:shouldStack
+											 contentView:nil
+											  completion:completion];
+	[alertView show];
+	return alertView;
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                       cancelTitle:(NSString *)cancelTitle
-                       otherTitles:(NSArray *)otherTitles
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+					   cancelTitle:(NSString *)cancelTitle
+					   otherTitles:(NSArray *)otherTitles
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    PXAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                             cancelTitle:cancelTitle
-                                             otherTitles:otherTitles
-                                      buttonsShouldStack:NO
-                                             contentView:nil
-                                              completion:completion];
-    [alertView show];
-    return alertView;
+	PXAlertView *alertView = [[self alloc] initWithTitle:title
+												 message:message
+											 cancelTitle:cancelTitle
+											 otherTitles:otherTitles
+									  buttonsShouldStack:NO
+											 contentView:nil
+											  completion:completion];
+	[alertView show];
+	return alertView;
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                       cancelTitle:(NSString *)cancelTitle
-                        otherTitle:(NSString *)otherTitle
-                       contentView:(UIView *)view
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+					   cancelTitle:(NSString *)cancelTitle
+						otherTitle:(NSString *)otherTitle
+					   contentView:(UIView *)view
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    PXAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                             cancelTitle:cancelTitle
-                                              otherTitle:otherTitle
-                                      buttonsShouldStack:NO
-                                             contentView:view
-                                              completion:completion];
-    [alertView show];
-    return alertView;
+	PXAlertView *alertView = [[self alloc] initWithTitle:title
+												 message:message
+											 cancelTitle:cancelTitle
+											  otherTitle:otherTitle
+									  buttonsShouldStack:NO
+											 contentView:view
+											  completion:completion];
+	[alertView show];
+	return alertView;
 }
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                       cancelTitle:(NSString *)cancelTitle
-                        otherTitle:(NSString *)otherTitle
-                buttonsShouldStack:(BOOL)shouldStack
-                       contentView:(UIView *)view
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+					   cancelTitle:(NSString *)cancelTitle
+						otherTitle:(NSString *)otherTitle
+				buttonsShouldStack:(BOOL)shouldStack
+					   contentView:(UIView *)view
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    PXAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                             cancelTitle:cancelTitle
-                                              otherTitle:otherTitle
-                                      buttonsShouldStack:shouldStack
-                                             contentView:view
-                                              completion:completion];
-    [alertView show];
-    return alertView;
+	PXAlertView *alertView = [[self alloc] initWithTitle:title
+												 message:message
+											 cancelTitle:cancelTitle
+											  otherTitle:otherTitle
+									  buttonsShouldStack:shouldStack
+											 contentView:view
+											  completion:completion];
+	[alertView show];
+	return alertView;
 }
 
 
 + (instancetype)showAlertWithTitle:(NSString *)title
-                           message:(NSString *)message
-                       cancelTitle:(NSString *)cancelTitle
-                       otherTitles:(NSArray *)otherTitles
-                       contentView:(UIView *)view
-                        completion:(PXAlertViewCompletionBlock)completion
+						   message:(NSString *)message
+					   cancelTitle:(NSString *)cancelTitle
+					   otherTitles:(NSArray *)otherTitles
+					   contentView:(UIView *)view
+						completion:(PXAlertViewCompletionBlock)completion
 {
-    PXAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                             cancelTitle:cancelTitle
-                                             otherTitles:otherTitles
-                                      buttonsShouldStack:NO
-                                             contentView:view
-                                              completion:completion];
-    [alertView show];
-    return alertView;
+	PXAlertView *alertView = [[self alloc] initWithTitle:title
+												 message:message
+											 cancelTitle:cancelTitle
+											 otherTitles:otherTitles
+									  buttonsShouldStack:NO
+											 contentView:view
+											  completion:completion];
+	[alertView show];
+	return alertView;
 }
 
 - (NSInteger)addButtonWithTitle:(NSString *)title
 {
-    UIButton *button = [self genericButton];
-    [button setTitle:title forState:UIControlStateNormal];
-
-    if (!self.cancelButton) {
-        button.titleLabel.font = [UIFont boldSystemFontOfSize:17];
-        self.cancelButton = button;
-        self.cancelButton.frame = CGRectMake(0, self.buttonsY, AlertViewWidth, AlertViewButtonHeight);
-    } else if (self.buttonsShouldStack) {
-        button.titleLabel.font = [UIFont systemFontOfSize:17];
-        self.otherButton = button;
-        
-        button.frame = self.cancelButton.frame;
-        
-        CGFloat lastButtonYOffset = self.cancelButton.frame.origin.y + AlertViewButtonHeight;
-        self.cancelButton.frame = CGRectMake(0, lastButtonYOffset, AlertViewWidth, AlertViewButtonHeight);
-        
-        CALayer *lineLayer = [self lineLayer];
-        lineLayer.frame = CGRectMake(0, lastButtonYOffset, AlertViewWidth, AlertViewLineLayerWidth);
-        [self.alertView.layer addSublayer:lineLayer];
-    } else if (self.buttons && [self.buttons count] > 1) {
-        UIButton *lastButton = (UIButton *)[self.buttons lastObject];
-        lastButton.titleLabel.font = [UIFont systemFontOfSize:17];
-        if ([self.buttons count] == 2) {
-            [self.verticalLine removeFromSuperlayer];
-            CALayer *lineLayer = [self lineLayer];
-            lineLayer.frame = CGRectMake(0, self.buttonsY + AlertViewButtonHeight, AlertViewWidth, AlertViewLineLayerWidth);
-            [self.alertView.layer addSublayer:lineLayer];
-            lastButton.frame = CGRectMake(0, self.buttonsY + AlertViewButtonHeight, AlertViewWidth, AlertViewButtonHeight);
-            self.cancelButton.frame = CGRectMake(0, self.buttonsY, AlertViewWidth, AlertViewButtonHeight);
-        }
-        CGFloat lastButtonYOffset = lastButton.frame.origin.y + AlertViewButtonHeight;
-        button.frame = CGRectMake(0, lastButtonYOffset, AlertViewWidth, AlertViewButtonHeight);
-    } else {
-        self.verticalLine = [self lineLayer];
-        self.verticalLine.frame = CGRectMake(AlertViewWidth/2, self.buttonsY, AlertViewLineLayerWidth, AlertViewButtonHeight);
-        [self.alertView.layer addSublayer:self.verticalLine];
-        button.frame = CGRectMake(AlertViewWidth/2, self.buttonsY, AlertViewWidth/2, AlertViewButtonHeight);
-        self.otherButton = button;
-        self.cancelButton.frame = CGRectMake(0, self.buttonsY, AlertViewWidth/2, AlertViewButtonHeight);
-        self.cancelButton.titleLabel.font = [UIFont systemFontOfSize:17];
-    }
-    
-    [self.alertView addSubview:button];
-    self.buttons = (self.buttons) ? [self.buttons arrayByAddingObject:button] : @[ button ];
-    return [self.buttons count] - 1;
+	UIButton *button = [self genericButton];
+	[button setTitle:title forState:UIControlStateNormal];
+	
+	if (!self.cancelButton) {
+		button.titleLabel.font = [UIFont boldSystemFontOfSize:17];
+		self.cancelButton = button;
+		self.cancelButton.frame = CGRectMake(0, self.buttonsY, AlertViewWidth, AlertViewButtonHeight);
+	} else if (self.buttonsShouldStack) {
+		button.titleLabel.font = [UIFont systemFontOfSize:17];
+		self.otherButton = button;
+		
+		button.frame = self.cancelButton.frame;
+		
+		CGFloat lastButtonYOffset = self.cancelButton.frame.origin.y + AlertViewButtonHeight;
+		self.cancelButton.frame = CGRectMake(0, lastButtonYOffset, AlertViewWidth, AlertViewButtonHeight);
+		
+		CALayer *lineLayer = [self lineLayer];
+		lineLayer.frame = CGRectMake(0, lastButtonYOffset, AlertViewWidth, AlertViewLineLayerWidth);
+		[self.alertView.layer addSublayer:lineLayer];
+	} else if (self.buttons && [self.buttons count] > 1) {
+		UIButton *lastButton = (UIButton *)[self.buttons lastObject];
+		lastButton.titleLabel.font = [UIFont systemFontOfSize:17];
+		if ([self.buttons count] == 2) {
+			[self.verticalLine removeFromSuperlayer];
+			CALayer *lineLayer = [self lineLayer];
+			lineLayer.frame = CGRectMake(0, self.buttonsY + AlertViewButtonHeight, AlertViewWidth, AlertViewLineLayerWidth);
+			[self.alertView.layer addSublayer:lineLayer];
+			lastButton.frame = CGRectMake(0, self.buttonsY + AlertViewButtonHeight, AlertViewWidth, AlertViewButtonHeight);
+			self.cancelButton.frame = CGRectMake(0, self.buttonsY, AlertViewWidth, AlertViewButtonHeight);
+		}
+		CGFloat lastButtonYOffset = lastButton.frame.origin.y + AlertViewButtonHeight;
+		button.frame = CGRectMake(0, lastButtonYOffset, AlertViewWidth, AlertViewButtonHeight);
+	} else {
+		self.verticalLine = [self lineLayer];
+		self.verticalLine.frame = CGRectMake(AlertViewWidth/2, self.buttonsY, AlertViewLineLayerWidth, AlertViewButtonHeight);
+		[self.alertView.layer addSublayer:self.verticalLine];
+		button.frame = CGRectMake(AlertViewWidth/2, self.buttonsY, AlertViewWidth/2, AlertViewButtonHeight);
+		self.otherButton = button;
+		self.cancelButton.frame = CGRectMake(0, self.buttonsY, AlertViewWidth/2, AlertViewButtonHeight);
+		self.cancelButton.titleLabel.font = [UIFont systemFontOfSize:17];
+	}
+	
+	[self.alertView addSubview:button];
+	self.buttons = (self.buttons) ? [self.buttons arrayByAddingObject:button] : @[ button ];
+	return [self.buttons count] - 1;
 }
 
 - (void)dismissWithClickedButtonIndex:(NSInteger)buttonIndex animated:(BOOL)animated
 {
-    if (buttonIndex >= 0 && buttonIndex < [self.buttons count]) {
-        [self dismiss:self.buttons[buttonIndex] animated:animated];
-    }
+	if (buttonIndex >= 0 && buttonIndex < [self.buttons count]) {
+		[self dismiss:self.buttons[buttonIndex] animated:animated];
+	}
 }
 
 - (void)setTapToDismissEnabled:(BOOL)enabled
 {
-    self.tap.enabled = enabled;
+	self.tap.enabled = enabled;
 }
 
 @end
@@ -695,34 +698,38 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
 
 + (instancetype)sharedInstance
 {
-    static PXAlertViewStack *_sharedInstance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        _sharedInstance = [[PXAlertViewStack alloc] init];
-        _sharedInstance.alertViews = [NSMutableArray array];
-    });
-
-    return _sharedInstance;
+	static PXAlertViewStack *_sharedInstance = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		_sharedInstance = [[PXAlertViewStack alloc] init];
+		_sharedInstance.alertViews = [NSMutableArray array];
+	});
+	
+	return _sharedInstance;
 }
 
 - (void)push:(PXAlertView *)alertView
 {
-    [self.alertViews addObject:alertView];
-    [alertView showInternal];
-    for (PXAlertView *av in self.alertViews) {
-        if (av != alertView) {
-            [av hide];
-        }
-    }
+	for (PXAlertView *av in self.alertViews) {
+		if (av != alertView) {
+			[av hide];
+		}
+		else {
+			return;
+		}
+	}
+	[self.alertViews addObject:alertView];
+	[alertView showInternal];
 }
 
 - (void)pop:(PXAlertView *)alertView
 {
-    [self.alertViews removeObject:alertView];
-    PXAlertView *last = [self.alertViews lastObject];
-    if (last) {
-        [last showInternal];
-    }
+	[alertView hide];
+	[self.alertViews removeObject:alertView];
+	PXAlertView *last = [self.alertViews lastObject];
+	if (last && !last.view.superview) {
+		[last showInternal];
+	}
 }
 
 @end

--- a/Classes/UIAlertView+PXAlertViewOverride.h
+++ b/Classes/UIAlertView+PXAlertViewOverride.h
@@ -1,9 +1,8 @@
 //
-//  PXAlertView.h
-//  PXAlertViewDemo
+//  UIAlertView+PXAlertViewOverride.h
+//  PXAlertView
 //
 //  Created by Bryan Way on 18/09/2014.
-//  Copyright (c) 2013 Panaxiom Ltd. All rights reserved.
 //
 
 #import "PXAlertView.h"

--- a/Classes/UIAlertView+PXAlertViewOverride.h
+++ b/Classes/UIAlertView+PXAlertViewOverride.h
@@ -5,7 +5,7 @@
 //  Created by Bryan Way on 18/09/2014.
 //
 
-// Uncomment next line to enable automatic implementation
+// Uncomment next line to enable automatic implementation or define PXALERT_SWIZZLING globally
 //#define PXALERT_SWIZZLING
 
 #ifdef PXALERT_SWIZZLING

--- a/Classes/UIAlertView+PXAlertViewOverride.h
+++ b/Classes/UIAlertView+PXAlertViewOverride.h
@@ -1,0 +1,16 @@
+//
+//  PXAlertView.h
+//  PXAlertViewDemo
+//
+//  Created by Bryan Way on 18/09/2014.
+//  Copyright (c) 2013 Panaxiom Ltd. All rights reserved.
+//
+
+#import "PXAlertView.h"
+#import <objc/runtime.h>
+
+@interface UIAlertView (PXAlertViewOverride)
+
+-(void)showWithContent:(UIView*)contentView;
+
+@end

--- a/Classes/UIAlertView+PXAlertViewOverride.h
+++ b/Classes/UIAlertView+PXAlertViewOverride.h
@@ -5,6 +5,11 @@
 //  Created by Bryan Way on 18/09/2014.
 //
 
+// Uncomment next line to enable automatic implementation
+//#define PXALERT_SWIZZLING
+
+#ifdef PXALERT_SWIZZLING
+
 #import "PXAlertView.h"
 #import <objc/runtime.h>
 
@@ -13,3 +18,5 @@
 -(void)showWithContent:(UIView*)contentView;
 
 @end
+
+#endif

--- a/Classes/UIAlertView+PXAlertViewOverride.m
+++ b/Classes/UIAlertView+PXAlertViewOverride.m
@@ -242,7 +242,7 @@
 			}
 			if([self.delegate respondsToSelector:@selector(alertView:didDismissWithButtonIndex:)])
 			{
-				[self.delegate alertView:self clickedButtonAtIndex:buttonIndex];
+				[self.delegate alertView:self didDismissWithButtonIndex:buttonIndex];
 			}
 		}
 		

--- a/Classes/UIAlertView+PXAlertViewOverride.m
+++ b/Classes/UIAlertView+PXAlertViewOverride.m
@@ -1,0 +1,356 @@
+//
+//  UIAlertView+PXAlertViewOverride.m
+//  PXAlertView
+//
+//  Created by Bryan Way on 18/09/2014
+//
+
+#import "UIAlertView+PXAlertViewOverride.h"
+
+@implementation UIAlertView (PXAlertViewOverride)
+
++ (void)load {
+    static dispatch_once_t dispatchOnceToken;
+    dispatch_once(&dispatchOnceToken, ^{
+        Class class = [self class];
+		
+        SEL originalInitWithTitleSelector = @selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:);
+        SEL swizzledInitWithTitleSelector = @selector(swizzled_initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:);
+		SEL originalShowSelector = @selector(show);
+        SEL swizzledShowSelector = @selector(swizzled_show);
+		SEL originalAddButtonWithTitleSelector = @selector(addButtonWithTitle:);
+        SEL swizzledAddButtonWithTitleSelector = @selector(swizzled_addButtonWithTitle:);
+		SEL originalGetVisibleSelector = @selector(getVisible);
+        SEL swizzledGetVisibleSelector = @selector(swizzled_getVisible);
+		SEL originalGetFirstOtherButtonIndexSelector = @selector(getFirstOtherButtonIndex);
+        SEL swizzledGetFirstOtherButtonIndexSelector = @selector(swizzled_getFirstOtherButtonIndex);
+		SEL originalGetNumberOfButtonsSelector = @selector(getNumberOfButtons);
+        SEL swizzledGetNumberOfButtonsSelector = @selector(swizzled_getNumberOfButtons);
+		SEL originalButtonTitleAtIndexSelector = @selector(getNumberOfButtons);
+        SEL swizzledButtonTitleAtIndexSelector = @selector(swizzled_getNumberOfButtons);
+		SEL originalDismissWithClickedButtonIndexSelector = @selector(dismissWithClickedButtonIndex:animated:);
+        SEL swizzledDismissWithClickedButtonIndexSelector = @selector(swizzled_dismissWithClickedButtonIndex:animated:);
+		SEL originalTextFieldAtIndexSelector = @selector(textFieldAtIndex:);
+        SEL swizzledTextFieldAtIndexSelector = @selector(swizzled_textFieldAtIndex:);
+		
+        Method originalInitWithTitleMethod = class_getInstanceMethod(class, originalInitWithTitleSelector);
+        Method swizzledInitWithTitleMethod = class_getInstanceMethod(class, swizzledInitWithTitleSelector);
+		Method originalShowMethod = class_getInstanceMethod(class, originalShowSelector);
+        Method swizzledShowMethod = class_getInstanceMethod(class, swizzledShowSelector);
+		Method originalAddButtonWithTitleMethod = class_getInstanceMethod(class, originalAddButtonWithTitleSelector);
+        Method swizzledAddBUttonWithTitleMethod = class_getInstanceMethod(class, swizzledAddButtonWithTitleSelector);
+		Method originalGetVisibleMethod = class_getInstanceMethod(class, originalGetVisibleSelector);
+        Method swizzledGetVisibleMethod = class_getInstanceMethod(class, swizzledGetVisibleSelector);
+		Method originalGetFirstOtherButtonIndexMethod = class_getInstanceMethod(class, originalGetFirstOtherButtonIndexSelector);
+        Method swizzledGetFirstOtherButtonIndexMethod = class_getInstanceMethod(class, swizzledGetFirstOtherButtonIndexSelector);
+		Method originalGetNumberOfButtonsMethod = class_getInstanceMethod(class, originalGetNumberOfButtonsSelector);
+        Method swizzledGetNumberOfButtonsMethod = class_getInstanceMethod(class, swizzledGetNumberOfButtonsSelector);
+		Method originalButtonTitleAtIndexMethod = class_getInstanceMethod(class, originalButtonTitleAtIndexSelector);
+        Method swizzledButtonTitleAtIndexMethod = class_getInstanceMethod(class, swizzledButtonTitleAtIndexSelector);
+		Method originalDismissWithClickedButtonIndexMethod = class_getInstanceMethod(class, originalDismissWithClickedButtonIndexSelector);
+        Method swizzledDismissWithClickedButtonIndexMethod = class_getInstanceMethod(class, swizzledDismissWithClickedButtonIndexSelector);
+		Method originalTextFieldAtIndexMethod = class_getInstanceMethod(class, originalTextFieldAtIndexSelector);
+        Method swizzledTextFieldAtIndexMethod = class_getInstanceMethod(class, swizzledTextFieldAtIndexSelector);
+		
+        if(class_addMethod(class, originalInitWithTitleSelector, method_getImplementation(swizzledInitWithTitleMethod), method_getTypeEncoding(swizzledInitWithTitleMethod)))
+		{
+            class_replaceMethod(class, swizzledInitWithTitleSelector, method_getImplementation(originalInitWithTitleMethod), method_getTypeEncoding(originalInitWithTitleMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalInitWithTitleMethod, swizzledInitWithTitleMethod);
+        }
+		
+		if(class_addMethod(class, originalShowSelector, method_getImplementation(swizzledShowMethod), method_getTypeEncoding(swizzledShowMethod)))
+		{
+            class_replaceMethod(class, swizzledShowSelector, method_getImplementation(originalShowMethod), method_getTypeEncoding(originalShowMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalShowMethod, swizzledShowMethod);
+        }
+		
+		if(class_addMethod(class, originalAddButtonWithTitleSelector, method_getImplementation(swizzledAddBUttonWithTitleMethod), method_getTypeEncoding(swizzledAddBUttonWithTitleMethod)))
+		{
+            class_replaceMethod(class, swizzledAddButtonWithTitleSelector, method_getImplementation(originalAddButtonWithTitleMethod), method_getTypeEncoding(originalAddButtonWithTitleMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalAddButtonWithTitleMethod, swizzledAddBUttonWithTitleMethod);
+        }
+		
+		if(class_addMethod(class, originalGetVisibleSelector, method_getImplementation(swizzledGetVisibleMethod), method_getTypeEncoding(swizzledGetVisibleMethod)))
+		{
+            class_replaceMethod(class, swizzledGetVisibleSelector, method_getImplementation(originalGetVisibleMethod), method_getTypeEncoding(originalGetVisibleMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalGetVisibleMethod, swizzledGetVisibleMethod);
+        }
+		
+		if(class_addMethod(class, originalGetFirstOtherButtonIndexSelector, method_getImplementation(swizzledGetFirstOtherButtonIndexMethod), method_getTypeEncoding(swizzledGetFirstOtherButtonIndexMethod)))
+		{
+            class_replaceMethod(class, swizzledGetFirstOtherButtonIndexSelector, method_getImplementation(originalGetNumberOfButtonsMethod), method_getTypeEncoding(originalGetNumberOfButtonsMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalGetFirstOtherButtonIndexMethod, swizzledGetFirstOtherButtonIndexMethod);
+        }
+		
+		if(class_addMethod(class, originalGetNumberOfButtonsSelector, method_getImplementation(swizzledGetNumberOfButtonsMethod), method_getTypeEncoding(swizzledGetNumberOfButtonsMethod)))
+		{
+            class_replaceMethod(class, swizzledGetNumberOfButtonsSelector, method_getImplementation(originalGetFirstOtherButtonIndexMethod), method_getTypeEncoding(originalGetFirstOtherButtonIndexMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalGetNumberOfButtonsMethod, swizzledGetNumberOfButtonsMethod);
+        }
+		
+		if(class_addMethod(class, originalButtonTitleAtIndexSelector, method_getImplementation(swizzledButtonTitleAtIndexMethod), method_getTypeEncoding(swizzledButtonTitleAtIndexMethod)))
+		{
+            class_replaceMethod(class, swizzledButtonTitleAtIndexSelector, method_getImplementation(originalButtonTitleAtIndexMethod), method_getTypeEncoding(originalButtonTitleAtIndexMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalButtonTitleAtIndexMethod, swizzledButtonTitleAtIndexMethod);
+        }
+		
+		if(class_addMethod(class, originalDismissWithClickedButtonIndexSelector, method_getImplementation(swizzledDismissWithClickedButtonIndexMethod), method_getTypeEncoding(swizzledDismissWithClickedButtonIndexMethod)))
+		{
+            class_replaceMethod(class, swizzledDismissWithClickedButtonIndexSelector, method_getImplementation(originalDismissWithClickedButtonIndexMethod), method_getTypeEncoding(originalDismissWithClickedButtonIndexMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalDismissWithClickedButtonIndexMethod, swizzledDismissWithClickedButtonIndexMethod);
+        }
+		
+		if(class_addMethod(class, originalTextFieldAtIndexSelector, method_getImplementation(swizzledTextFieldAtIndexMethod), method_getTypeEncoding(swizzledTextFieldAtIndexMethod)))
+		{
+            class_replaceMethod(class, swizzledTextFieldAtIndexSelector, method_getImplementation(originalTextFieldAtIndexMethod), method_getTypeEncoding(originalTextFieldAtIndexMethod));
+        }
+		else
+		{
+            method_exchangeImplementations(originalTextFieldAtIndexMethod, swizzledTextFieldAtIndexMethod);
+        }
+    });
+}
+
+//	Swizzle methods
+
+- (id)swizzled_initWithTitle:(NSString *)title message:(NSString *)message delegate:(id)delegate cancelButtonTitle:(NSString *)cancelButtonTitle otherButtonTitles:(NSString *)otherButtonTitles, ...
+{
+	if([super init])
+	{
+		self.delegate = delegate;
+		self.title = title;
+		self.message = message;
+		
+		self.cancelButtonIndex = 0;
+		objc_setAssociatedObject(self, "cancelButtonTitle", cancelButtonTitle, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+		
+		NSMutableArray *otherButtonTitleList = [[NSMutableArray alloc] init];
+		
+		if(otherButtonTitles)
+		{
+			[otherButtonTitleList addObject:otherButtonTitles];
+
+			va_list args;
+			va_start(args, otherButtonTitles);
+			
+			NSString *otherButtonTitleEntry = nil;
+			while((otherButtonTitleEntry = va_arg(args, NSString*)))
+			{
+				[otherButtonTitleList addObject:otherButtonTitleEntry];
+			}
+			va_end(args);
+		}
+
+		objc_setAssociatedObject(self, "otherButtonTitles", otherButtonTitleList, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	}
+	return self;
+}
+
+-(void)swizzled_show
+{
+	[self showWithContent:nil];
+}
+
+-(void)showWithContent:(UIView*)contentView
+{
+	if(self.alertViewStyle != UIAlertViewStyleDefault)
+	{
+		if(contentView)
+		{
+			clog(@"Warning: Unable to display contentView when alertViewStyle != UIAlertViewStyleDefault. contentView will not be displayed.");
+		}
+		contentView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 270.0, (UIAlertViewStyleLoginAndPasswordInput ? 77.0 : 36.0)}];
+		
+		UITextField *textField = nil;
+		
+		NSMutableArray *alertBoxTextFields = [[NSMutableArray alloc] init];
+		if(self.alertViewStyle == UIAlertViewStylePlainTextInput || self.alertViewStyle == UIAlertViewStyleLoginAndPasswordInput)
+		{
+			textField = [[UITextField alloc] initWithFrame:(CGRect){20.0, 0, 230.0, 26.0}];
+			textField.backgroundColor = [UIColor whiteColor];
+			[alertBoxTextFields addObject:textField];
+			[contentView addSubview:textField];
+		}
+		
+		if(self.alertViewStyle == UIAlertViewStyleSecureTextInput || self.alertViewStyle == UIAlertViewStyleLoginAndPasswordInput)
+		{
+			textField = [[UITextField alloc] initWithFrame:(CGRect){20.0, (UIAlertViewStyleLoginAndPasswordInput ? 36.0 : 0), 230.0, 31.0}];
+			textField.backgroundColor = [UIColor whiteColor];
+			if(UIAlertViewStyleSecureTextInput)
+			{
+				textField.secureTextEntry = YES;
+			}
+			[alertBoxTextFields addObject:textField];
+			[contentView addSubview:textField];
+		}
+		objc_setAssociatedObject(self, "alertBoxTextFields", alertBoxTextFields, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	}
+	
+	if(self.delegate)
+	{
+		if([self.delegate respondsToSelector:@selector(alertViewShouldEnableFirstOtherButton:)])
+		{
+			[self.delegate alertViewShouldEnableFirstOtherButton:self]; // This has no correspondence with PXAlertView. Calling incase any code must be executed in this delegated method.
+		}
+		
+		if([self.delegate respondsToSelector:@selector(willPresentAlertView:)])
+		{
+			[self.delegate willPresentAlertView:self];
+		}
+	}
+	
+	PXAlertView* alertView = [PXAlertView showAlertWithTitle:self.title message:self.message cancelTitle:(NSString*)objc_getAssociatedObject(self, "cancelButtonTitle") otherTitles:(NSMutableArray*)objc_getAssociatedObject(self, "otherButtonTitles") contentView:contentView completion:^(BOOL cancelled, NSInteger buttonIndex) {
+		if(self.delegate)
+		{
+			if(cancelled && [self.delegate respondsToSelector:@selector(alertViewCancel:)])
+			{
+				[self.delegate alertViewCancel:self];
+			}
+			if([self.delegate respondsToSelector:@selector(alertView:clickedButtonAtIndex:)])
+			{
+				[self.delegate alertView:self clickedButtonAtIndex:buttonIndex];
+			}
+			if([self.delegate respondsToSelector:@selector(alertView:willDismissWithButtonIndex:)])
+			{
+				[self.delegate alertView:self willDismissWithButtonIndex:buttonIndex];
+			}
+			if([self.delegate respondsToSelector:@selector(alertView:didDismissWithButtonIndex:)])
+			{
+				[self.delegate alertView:self clickedButtonAtIndex:buttonIndex];
+			}
+		}
+		
+		objc_setAssociatedObject(self, "PXAlertViewInstance", nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	}];
+	[alertView setTapToDismissEnabled:NO]; // Default behavior like iOS. Best compatibility.
+	
+	objc_setAssociatedObject(self, "PXAlertViewInstance", alertView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	
+	if(self.delegate && [self.delegate respondsToSelector:@selector(didPresentAlertView::)])
+	{
+		[self.delegate didPresentAlertView:self];
+	}
+}
+
+- (NSInteger)swizzled_addButtonWithTitle:(NSString *)title
+{
+	PXAlertView* alertView = objc_getAssociatedObject(self, "PXAlertViewInstance");
+	if(alertView)
+	{
+		return [alertView addButtonWithTitle:title];
+	}
+	else
+	{
+		if(!self.message)
+		{
+			self.message = title;
+			return 0;
+		}
+		else
+		{
+			NSMutableArray* otherButtonTitles = objc_getAssociatedObject(self, "otherButtonTitles");
+			if(!otherButtonTitles)
+			{
+				otherButtonTitles = [[NSMutableArray alloc] init];
+				objc_setAssociatedObject(self, "otherButtonTitles", otherButtonTitles, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+			}
+			
+			[otherButtonTitles addObject:title];
+			return [otherButtonTitles count];
+		}
+	}
+	return -1;
+}
+
+- (NSString*)swizzled_buttonTitleAtIndex:(NSInteger)buttonIndex
+{
+	id tmpObj = objc_getAssociatedObject(self, "cancelButtonTitle");
+	if(buttonIndex == 0 && tmpObj)
+	{
+		return (NSString*)tmpObj;
+	}
+	else if(buttonIndex > 0)
+	{
+		buttonIndex--;
+		NSMutableArray* otherButtonTitles = objc_getAssociatedObject(self, "otherButtonTitles");
+		if(buttonIndex < [otherButtonTitles count])
+		{
+			return [otherButtonTitles objectAtIndex:buttonIndex];
+		}
+	}
+	return nil;
+}
+
+- (void)swizzled_dismissWithClickedButtonIndex:(NSInteger)buttonIndex animated:(BOOL)animated
+{
+	PXAlertView* alertView = objc_getAssociatedObject(self, "PXAlertViewInstance");
+	if(alertView)
+	{
+		[alertView dismissWithClickedButtonIndex:buttonIndex animated:animated];
+	}
+}
+
+-(BOOL)swizzled_getVisible
+{
+	if(objc_getAssociatedObject(self, "PXAlertViewInstance"))
+	{
+		return YES;
+	}
+	return NO;
+}
+
+-(NSInteger)swizzled_getFirstOtherButtonIndex
+{
+	NSMutableArray *array = objc_getAssociatedObject(self, "otherButtonTitles");
+	if(array && [array count] > 0)
+	{
+		return 0;
+	}
+	return -1;
+}
+
+-(NSInteger)swizzled_getNumberOfButtons
+{
+	NSMutableArray *array = objc_getAssociatedObject(self, "otherButtonTitles");
+	if(array)
+	{
+		return 1 + [array count];
+	}
+	return 1;
+}
+
+- (UITextField *)swizzled_textFieldAtIndex:(NSInteger)textFieldIndex
+{
+	NSMutableArray *alertBoxTextFields = objc_getAssociatedObject(self, "alertBoxTextFields");
+	if(alertBoxTextFields && [alertBoxTextFields count] > textFieldIndex)
+	{
+		return [alertBoxTextFields objectAtIndex:textFieldIndex];
+	}
+	return nil;
+}
+
+@end

--- a/Classes/UIAlertView+PXAlertViewOverride.m
+++ b/Classes/UIAlertView+PXAlertViewOverride.m
@@ -7,6 +7,8 @@
 
 #import "UIAlertView+PXAlertViewOverride.h"
 
+#ifdef PXALERT_SWIZZLING
+
 @implementation UIAlertView (PXAlertViewOverride)
 
 + (void)load {
@@ -354,3 +356,5 @@
 }
 
 @end
+
+#endif

--- a/Classes/UIAlertView+PXAlertViewOverride.m
+++ b/Classes/UIAlertView+PXAlertViewOverride.m
@@ -9,6 +9,8 @@
 
 #ifdef PXALERT_SWIZZLING
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
 @implementation UIAlertView (PXAlertViewOverride)
 
 + (void)load {
@@ -183,7 +185,7 @@
 	{
 		if(contentView)
 		{
-			clog(@"Warning: Unable to display contentView when alertViewStyle != UIAlertViewStyleDefault. contentView will not be displayed.");
+			NSLog(@"Warning: Unable to display contentView when alertViewStyle != UIAlertViewStyleDefault. contentView will not be displayed.");
 		}
 		contentView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 270.0, (UIAlertViewStyleLoginAndPasswordInput ? 77.0 : 36.0)}];
 		
@@ -356,5 +358,7 @@
 }
 
 @end
+
+#pragma clang diagnostic pop
 
 #endif

--- a/PXAlertViewDemo.xcodeproj/project.pbxproj
+++ b/PXAlertViewDemo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		37CD3A5A181526A1009FC40D /* PXAlertView+Customization.m in Sources */ = {isa = PBXBuildFile; fileRef = 37CD3A59181526A1009FC40D /* PXAlertView+Customization.m */; };
 		37CD3A5B181526A1009FC40D /* PXAlertView+Customization.m in Sources */ = {isa = PBXBuildFile; fileRef = 37CD3A59181526A1009FC40D /* PXAlertView+Customization.m */; };
+		7F99B3721A1BF53400E09D88 /* UIAlertView+PXAlertViewOverride.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F99B3711A1BF53400E09D88 /* UIAlertView+PXAlertViewOverride.m */; };
 		FA11B68217F3867100236222 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA11B68117F3867100236222 /* Foundation.framework */; };
 		FA11B68417F3867100236222 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA11B68317F3867100236222 /* CoreGraphics.framework */; };
 		FA11B68617F3867100236222 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA11B68517F3867100236222 /* UIKit.framework */; };
@@ -40,6 +41,8 @@
 /* Begin PBXFileReference section */
 		37CD3A58181526A1009FC40D /* PXAlertView+Customization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PXAlertView+Customization.h"; sourceTree = "<group>"; };
 		37CD3A59181526A1009FC40D /* PXAlertView+Customization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PXAlertView+Customization.m"; sourceTree = "<group>"; };
+		7F99B3701A1BF53400E09D88 /* UIAlertView+PXAlertViewOverride.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertView+PXAlertViewOverride.h"; sourceTree = "<group>"; };
+		7F99B3711A1BF53400E09D88 /* UIAlertView+PXAlertViewOverride.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAlertView+PXAlertViewOverride.m"; sourceTree = "<group>"; };
 		FA11B67E17F3867100236222 /* PXAlertViewDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PXAlertViewDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA11B68117F3867100236222 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		FA11B68317F3867100236222 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -166,6 +169,8 @@
 		FA53E9531809B3BC001E6B60 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				7F99B3701A1BF53400E09D88 /* UIAlertView+PXAlertViewOverride.h */,
+				7F99B3711A1BF53400E09D88 /* UIAlertView+PXAlertViewOverride.m */,
 				37CD3A58181526A1009FC40D /* PXAlertView+Customization.h */,
 				37CD3A59181526A1009FC40D /* PXAlertView+Customization.m */,
 				FA53E9541809B3BC001E6B60 /* PXAlertView.h */,
@@ -274,6 +279,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA11B69B17F3867100236222 /* PXViewController.m in Sources */,
+				7F99B3721A1BF53400E09D88 /* UIAlertView+PXAlertViewOverride.m in Sources */,
 				FA11B69217F3867100236222 /* PXAppDelegate.m in Sources */,
 				FA11B68E17F3867100236222 /* main.m in Sources */,
 				FA53E9561809B3BC001E6B60 /* PXAlertView.m in Sources */,

--- a/PXAlertViewDemo/PXViewController.m
+++ b/PXAlertViewDemo/PXViewController.m
@@ -75,7 +75,7 @@
 - (IBAction)showLargeAlertView:(id)sender
 {
     [PXAlertView showAlertWithTitle:@"Why this is a larger title! Even larger than the largest large thing that ever was large in a very large way."
-                            message:@"Oh my this looks like a nice message. Yes it does, and it can span multiple lines... all the way down."
+                            message:@"Oh my this looks like a nice message. Yes it does, and it can span multiple lines... all the way down.\n\nBut what's this? Even more lines? Why yes, now we can have even more content to show the world. Why? Because now you don't have to worry about the text overflowing off the screen. If text becomes too long to fit on the users display, it'll simply overflow and allow for the user to scroll. So now you're free to write however much you wish to write in an alert. A novel? An epic? Doesn't matter, because it can all now fit*. \n\n\n*Disclaimer: Within hardware and technical limitations, of course.\n\n To demonstrate, watch here:\nHere is a line.\nAnd here is another.\nAnd another.\nAnd another.\nAaaaaaand another.\nOh lookie here, AND another.\nAnd here's one more.\nFor good measure.\nAnd hello, newline.\n\n\nFeel free to expand your textual minds."
                         cancelTitle:@"Ok thanks, that's grand"
                          completion:^(BOOL cancelled, NSInteger buttonIndex) {
                              if (cancelled) {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ See [PXAlertView.h](Classes/PXAlertView.h) for the complete API.
 
 * Add style that matches iOS 7 exactly
 * Ability to dynamically specify the styling of AlertView: default/dark
-* Allow usage using the same API methods as UIAlertView and delegate.
 
 ## License
 


### PR DESCRIPTION
Changed to use more robust method of detecting screen frame when presenting. This fixes rotation errors on the new iOS 8.

Keyboard dodging added, so when a control that utilizes the keyboard is on the alert, the keyboard will not cover the alert.

UIAlertView swizzling added for implementing PXAlertView without manually changing pre-existing code. This can be enabled by defining PXALERT_SWIZZLING in UIAlertView+PXAlertViewOverride.h. (Check the comments)