### PR TITLE
We must always create own UIWindowLevelAlert window, because existing may be used by other instance or different UIViewController

### DIFF
--- a/Classes/PXAlertView.m
+++ b/Classes/PXAlertView.m
@@ -86,13 +86,10 @@ static const CGFloat AlertViewLineLayerWidth = 0.5;
     self = [super init];
     if (self) {
         self.mainWindow = [self windowWithLevel:UIWindowLevelNormal];
-        self.alertWindow = [self windowWithLevel:UIWindowLevelAlert];
         
-        if (!self.alertWindow) {
-            self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-            self.alertWindow.windowLevel = UIWindowLevelAlert;
-            self.alertWindow.backgroundColor = [UIColor clearColor];
-        }
+        self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+        self.alertWindow.windowLevel = UIWindowLevelAlert;
+        self.alertWindow.backgroundColor = [UIColor clearColor];
         self.alertWindow.rootViewController = self;
         
         CGRect frame = [self frameForOrientation:self.interfaceOrientation];


### PR DESCRIPTION
It fixes conflicts with some other libs, like [ActionSheetPicker-3.0](https://github.com/skywinder/ActionSheetPicker-3.0), and #34 too.
