### PR TITLE
Reset button custom background color on drag exit event

### DIFF
--- a/Classes/PXAlertView+Customization.m
+++ b/Classes/PXAlertView+Customization.m
@@ -161,8 +161,6 @@ void * const kNonSelectedAllBGKey = (void * const) &kNonSelectedAllBGKey;
     objc_setAssociatedObject(self, kOtherBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     [self.otherButton addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDown];
     [self.otherButton addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragEnter];
-    [self.otherButton addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchUpInside];
-    [self.otherButton addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchUpOutside];
     [self.otherButton addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragExit];
 }
 

--- a/Classes/PXAlertView+Customization.m
+++ b/Classes/PXAlertView+Customization.m
@@ -10,8 +10,11 @@
 #import <objc/runtime.h>
 
 void * const kCancelBGKey = (void * const) &kCancelBGKey;
+void * const kNonSelectedCancelBGKey = (void * const) &kNonSelectedCancelBGKey;
 void * const kOtherBGKey = (void * const) &kOtherBGKey;
+void * const kNonSelectedOtherBGKey = (void * const) &kNonSelectedOtherBGKey;
 void * const kAllBGKey = (void * const) &kAllBGKey;
+void * const kNonSelectedAllBGKey = (void * const) &kNonSelectedAllBGKey;
 
 @interface PXAlertView ()
 
@@ -84,11 +87,25 @@ void * const kAllBGKey = (void * const) &kAllBGKey;
     }
 }
 
+- (void)setNonSelectedCustomBackgroundColorForButton:(id)sender
+{
+    if (sender == self.cancelButton && [self nonSelectedCancelButtonBackgroundColor]) {
+        self.cancelButton.backgroundColor = [self nonSelectedCancelButtonBackgroundColor];
+    } else if (sender == self.otherButton && [self nonSelectedOtherButtonBackgroundColor]) {
+        self.otherButton.backgroundColor = [self nonSelectedOtherButtonBackgroundColor];
+    } else if ([self nonSelectedAllButtonsBackgroundColor]) {
+        [sender setBackgroundColor:[self nonSelectedAllButtonsBackgroundColor]];
+    } else {
+        [sender setBackgroundColor:[UIColor clearColor]];
+    }
+}
+
 - (void)setCancelButtonBackgroundColor:(UIColor *)color
 {
     objc_setAssociatedObject(self, kCancelBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     [self.cancelButton addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDown];
     [self.cancelButton addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragEnter];
+    [self.cancelButton addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragExit];
 }
 
 - (UIColor *)cancelButtonBackgroundColor
@@ -98,7 +115,13 @@ void * const kAllBGKey = (void * const) &kAllBGKey;
 
 - (void)setCancelButtonNonSelectedBackgroundColor:(UIColor *)color
 {
+    objc_setAssociatedObject(self, kNonSelectedCancelBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     self.cancelButton.backgroundColor = color;
+}
+
+- (UIColor *)nonSelectedCancelButtonBackgroundColor
+{
+    return objc_getAssociatedObject(self, kNonSelectedCancelBGKey);
 }
 
 - (void)setAllButtonsBackgroundColor:(UIColor *)color
@@ -109,6 +132,7 @@ void * const kAllBGKey = (void * const) &kAllBGKey;
     for (UIButton *button in self.buttons) {
         [button addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDown];
         [button addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragEnter];
+        [button addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragExit];
     }
 }
 
@@ -119,9 +143,17 @@ void * const kAllBGKey = (void * const) &kAllBGKey;
 
 - (void)setAllButtonsNonSelectedBackgroundColor:(UIColor *)color
 {
+    objc_setAssociatedObject(self, kNonSelectedOtherBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, kNonSelectedCancelBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, kNonSelectedAllBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     for (UIButton *button in self.buttons) {
         button.backgroundColor = color;
     }
+}
+
+- (UIColor *)nonSelectedAllButtonsBackgroundColor
+{
+    return objc_getAssociatedObject(self, kNonSelectedAllBGKey);
 }
 
 - (void)setOtherButtonBackgroundColor:(UIColor *)color
@@ -129,6 +161,9 @@ void * const kAllBGKey = (void * const) &kAllBGKey;
     objc_setAssociatedObject(self, kOtherBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     [self.otherButton addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDown];
     [self.otherButton addTarget:self action:@selector(setCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragEnter];
+    [self.otherButton addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchUpInside];
+    [self.otherButton addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchUpOutside];
+    [self.otherButton addTarget:self action:@selector(setNonSelectedCustomBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragExit];
 }
 
 - (UIColor *)otherButtonBackgroundColor
@@ -138,7 +173,13 @@ void * const kAllBGKey = (void * const) &kAllBGKey;
 
 - (void)setOtherButtonNonSelectedBackgroundColor:(UIColor *)color
 {
+    objc_setAssociatedObject(self, kNonSelectedOtherBGKey, color, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     self.otherButton.backgroundColor = color;
+}
+
+- (UIColor *)nonSelectedOtherButtonBackgroundColor
+{
+    return objc_getAssociatedObject(self, kNonSelectedOtherBGKey);
 }
 
 #pragma mark Buttons Text Colors

--- a/Classes/PXAlertView.m
+++ b/Classes/PXAlertView.m
@@ -311,6 +311,7 @@ static const CGFloat AlertViewVerticalEdgeMinMargin = 25;
 	[button setTitleColor:[UIColor colorWithWhite:0.25 alpha:1] forState:UIControlStateHighlighted];
 	[button addTarget:self action:@selector(dismiss:) forControlEvents:UIControlEventTouchUpInside];
 	[button addTarget:self action:@selector(setBackgroundColorForButton:) forControlEvents:UIControlEventTouchDown];
+    [button addTarget:self action:@selector(setBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragEnter];
 	[button addTarget:self action:@selector(clearBackgroundColorForButton:) forControlEvents:UIControlEventTouchDragExit];
 	return button;
 }

--- a/PXAlertViewDemo/PXViewController.m
+++ b/PXAlertViewDemo/PXViewController.m
@@ -100,8 +100,17 @@
                              }
                          }];
     
-    [alert setCancelButtonBackgroundColor:[UIColor blueColor]];
-    [alert setOtherButtonBackgroundColor:[UIColor redColor]];
+    UIColor *blueNormal = [UIColor blueColor];
+    UIColor *blueSelected = [UIColor colorWithRed:0.5 green:0.5 blue:1 alpha:1];
+    [alert setCancelButtonNonSelectedBackgroundColor:blueNormal];
+    [alert setCancelButtonBackgroundColor:blueSelected];
+    
+    UIColor *redNormal = [UIColor redColor];
+    UIColor *redSelected = [UIColor colorWithRed:1 green:0.5 blue:0.5 alpha:1];
+    [alert setOtherButtonNonSelectedBackgroundColor:redNormal];
+    [alert setOtherButtonBackgroundColor:redSelected];
+    
+    [alert setAllButtonsTextColor:[UIColor whiteColor]];
 }
 
 - (IBAction)showTwoStackedButtonAlertView:(id)sender
@@ -119,8 +128,17 @@
                                                   }
                                               }];
     
-    [alert setCancelButtonBackgroundColor:[UIColor blueColor]];
-    [alert setOtherButtonBackgroundColor:[UIColor redColor]];
+    UIColor *blueNormal = [UIColor blueColor];
+    UIColor *blueSelected = [UIColor colorWithRed:0.5 green:0.5 blue:1 alpha:1];
+    [alert setCancelButtonNonSelectedBackgroundColor:blueNormal];
+    [alert setCancelButtonBackgroundColor:blueSelected];
+    
+    UIColor *redNormal = [UIColor redColor];
+    UIColor *redSelected = [UIColor colorWithRed:1 green:0.5 blue:0.5 alpha:1];
+    [alert setOtherButtonNonSelectedBackgroundColor:redNormal];
+    [alert setOtherButtonBackgroundColor:redSelected];
+    
+    [alert setAllButtonsTextColor:[UIColor whiteColor]];
 }
 
 - (IBAction)showMultiButtonAlertView:(id)sender


### PR DESCRIPTION
* Reset button standard background color on drag enter event
* Update 2-button demo (red/blue pill) examples to show custom button colors